### PR TITLE
Change conditions for 'Expand tweet'

### DIFF
--- a/files/bundle.js
+++ b/files/bundle.js
@@ -22225,13 +22225,12 @@ document.body.addEventListener("click", function (e) {
 		} else this.withPrettyEngagements = !1
 	}, TD.services.TwitterStatus.prototype._generateHTMLText = function() {
 		this.htmlText = TD.util.transform(this.text, this.entities);
-		let cleanText = this.text.replace(/\shttps:\/\/t.co\/[a-zA-Z0-9\-]{8,10}$/, "");
-		if(cleanText.endsWith("…")) {
-			var tweetLength = tweetUtil.getTweetLength(this.text.trim(), configUtil.getConfiguration());
-			if(tweetLength >= 275 && tweetLength < 400) {
-				let id = this.retweetedStatus ? this.retweetedStatus.id : this.id;
-				this.htmlText += ` <a href="https://twitter.com/${this.user.screenName}/status/${id}" onclick="expandTweet(event, '${id}')">Expand tweet</a>`;
-			};
+		const urlsInText = this.text.match(/https:\/\/t.co\/[a-zA-Z0-9\-]{8,10}/g) || [];
+		const endsWithEllipsis = this.text.replace(/https:\/\/t.co\/[a-zA-Z0-9\-]{8,10}/g, "").trim().endsWith("…");
+		const isExpandable = endsWithEllipsis && urlsInText.some(urlInText => !this.entities.urls.some(entityUrl => entityUrl.url === urlInText))
+		if (isExpandable) {
+			let id = this.retweetedStatus ? this.retweetedStatus.id : this.id;
+			this.htmlText += ` <a href="https://twitter.com/${this.user.screenName}/status/${id}" onclick="expandTweet(event, '${id}')">Expand tweet</a>`;
 		}
 	}, TD.services.TwitterStatus.prototype.getMainUser = function() {
 		return this.retweetedStatus ? this.retweetedStatus.user : this.user


### PR DESCRIPTION
The timing for truncating long tweets is determined by the presence of a space or a newline character, or by exceeding a certain number of characters. Therefore, with languages like Japanese that do not separate words with spaces, truncation of the subsequent text may occur at a significantly early stage when entering a long text. Consequently, the conditions for implementing an "Expand Tweet" have been relaxed. If the end of a tweet is marked with "…" and the tweet does not contain media, and if the URL attached to the end is not included in entities.urls, it is safe to determine that it is 100% a long tweet without any issues. However, if the tweet contains media, the URL at the end will be overwritten by the URL of the media, making accurate determination impossible. This issue will be set aside for now.

Processing may be branched based on whether there are multiple half-width spaces. However, on Twitter, "..." is likely used more often than "…" in languages that do not require a conversion step during text input, as with Japanese. Therefore, it might not be necessary to be overly concerned about this.